### PR TITLE
feat: Implement random mood selection and add new moods

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,16 +17,7 @@
             <!-- 気分選択エリア -->
             <section class="mood-selection">
                 <h2>今の気分はどれですか？</h2>
-                <div class="mood-buttons">
-                    <button class="mood-btn" data-mood="happy">😊 ハッピー</button>
-                    <button class="mood-btn" data-mood="relax">😌 リラックス</button>
-                    <button class="mood-btn" data-mood="energetic">⚡ エネルギッシュ</button>
-                    <button class="mood-btn" data-mood="melancholy">😔 メランコリー</button>
-                    <button class="mood-btn" data-mood="creative">🎨 クリエイティブ</button>
-                    <button class="mood-btn" data-mood="romantic">💕 ロマンチック</button>
-                    <button class="mood-btn" data-mood="focus">🎯 集中</button>
-                    <button class="mood-btn" data-mood="peace">🕊️ 平穏</button>
-                </div>
+                <div class="mood-buttons"></div>
             </section>
 
             <!-- カラーパレット表示エリア -->

--- a/script.js
+++ b/script.js
@@ -1,3 +1,16 @@
+const allMoods = [
+    { key: 'happy', displayText: '😊 ハッピー' },
+    { key: 'relax', displayText: '😌 リラックス' },
+    { key: 'energetic', displayText: '⚡ エネルギッシュ' },
+    { key: 'melancholy', displayText: '😔 メランコリー' },
+    { key: 'creative', displayText: '🎨 クリエイティブ' },
+    { key: 'romantic', displayText: '💕 ロマンチック' },
+    { key: 'focus', displayText: '🎯 集中' },
+    { key: 'peace', displayText: '🕊️ 平穏' },
+    { key: 'shindoi', displayText: '💦 しんどい' },
+    { key: 'saikou', displayText: '💦 最高' }
+];
+
 const moodColorMap = {
     happy: {
         name: 'ハッピー',
@@ -70,6 +83,24 @@ const moodColorMap = {
             { hex: '#F0FFFF', name: '水色' },
             { hex: '#FFFAF0', name: '白' }
         ]
+    },
+    shindoi: {
+        name: 'しんどい',
+        colors: [
+            { hex: '#2F4F4F', name: '暗いスレートグレー' },
+            { hex: '#696969', name: 'ディムグレー' },
+            { hex: '#708090', name: 'スレートグレー' },
+            { hex: '#B0C4DE', name: 'ライトスチールブルー' }
+        ]
+    },
+    saikou: {
+        name: '最高',
+        colors: [
+            { hex: '#FFD700', name: 'ゴールド' },
+            { hex: '#FF1493', name: 'ディープピンク' },
+            { hex: '#32CD32', name: 'ライムグリーン' },
+            { hex: '#1E90FF', name: 'ドジャーブルー' }
+        ]
     }
 };
 
@@ -80,7 +111,29 @@ class MoodColorApp {
     }
 
     init() {
-        this.bindEvents();
+        this.displayRandomMoods(); // Generate buttons first
+        this.bindEvents();      // Then bind events to them
+    }
+
+    displayRandomMoods() {
+        const moodButtonsContainer = document.querySelector('.mood-buttons');
+        if (!moodButtonsContainer) {
+            console.error('Mood buttons container not found!');
+            return;
+        }
+        moodButtonsContainer.innerHTML = ''; // Clear existing buttons
+
+        // Shuffle and select 5 moods
+        const shuffledMoods = [...allMoods].sort(() => 0.5 - Math.random());
+        const selectedMoods = shuffledMoods.slice(0, 5);
+
+        selectedMoods.forEach(mood => {
+            const button = document.createElement('button');
+            button.className = 'mood-btn';
+            button.dataset.mood = mood.key;
+            button.textContent = mood.displayText;
+            moodButtonsContainer.appendChild(button);
+        });
     }
 
     bindEvents() {


### PR DESCRIPTION
This commit introduces two main changes to the mood color application:

1.  **Random Mood Display**:
    - The application now dynamically displays 5 randomly selected mood options each time the page loads.
    - Previously, all mood options were hardcoded and static in `index.html`.
    - This change involved:
        - Removing hardcoded buttons from `index.html`.
        - Creating a comprehensive list of all moods (`allMoods`) in `script.js`. - Implementing a `displayRandomMoods` function in `script.js` to shuffle moods, select 5, and generate corresponding buttons. - Updating the initialization logic to call `displayRandomMoods` before binding event listeners.

2.  **New Mood Options Added**:
    - Two new mood options have been added: - "💦 しんどい" (Tough/Tiring) with `data-mood="shindoi"` - "💦 最高" (Awesome/The Best) with `data-mood="saikou"`
    - Corresponding color palettes for these new moods have been added to `moodColorMap` in `script.js`.

These changes enhance your experience by providing a varied set of mood choices on each visit and expanding the range of available moods.